### PR TITLE
Prevent passing null to write definition file

### DIFF
--- a/src/Service/SassManager.php
+++ b/src/Service/SassManager.php
@@ -69,10 +69,12 @@ class SassManager {
     $pathDefinitionTarget = \Drupal::root() . '/sites/default/files/styling_profiles/' . $profile->id() . '/iq_barrio/resources/sass/_definitions.scss';
     $pathDefinitionSource = \Drupal::root() . '/themes/custom/iq_barrio/resources/sass/_template.scss.txt';
 
-    $this->barrioService->writeDefinitionsFile(
-      $stylingValues,
-      $pathDefinitionTarget,
-      $pathDefinitionSource
-    );
+    if (empty($stylingValues)) {
+      $this->barrioService->writeDefinitionsFile(
+        $stylingValues,
+        $pathDefinitionTarget,
+        $pathDefinitionSource
+      );
+    }
   }
 }


### PR DESCRIPTION
Prevent error if a styling profile doesn't have any styles set.