### PR TITLE
DUP-69: use custom asset resolver to add profile id to cache id

### DIFF
--- a/src/Asset/AssetResolver.php
+++ b/src/Asset/AssetResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\styling_profiles\Asset;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Asset\AssetResolver as CoreAssetResolver;
+use Drupal\Core\Asset\AttachedAssetsInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Language\LanguageInterface;
+
+/**
+ * Custom Asset Resolver class dependent on the styling profile.
+ */
+class AssetResolver extends CoreAssetResolver {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCssAssets(AttachedAssetsInterface $assets, $optimize, ?LanguageInterface $language = NULL) {
+    if (!$assets->getLibraries()) {
+      return [];
+    }
+    $libraries_to_load = $this->getLibrariesToLoad($assets);
+    foreach ($libraries_to_load as $key => $library) {
+      [$extension, $name] = explode('/', $library, 2);
+      $definition = $this->libraryDiscovery->getLibraryByName($extension, $name);
+      if (empty($definition['css'])) {
+        unset($libraries_to_load[$key]);
+      }
+    }
+    $libraries_to_load = array_values($libraries_to_load);
+    if (!$libraries_to_load) {
+      return [];
+    }
+    if (!isset($language)) {
+      $language = $this->languageManager->getCurrentLanguage();
+    }
+
+    $theme_info = $this->themeManager->getActiveTheme();
+    $styleProfileRuleHandlerManager = \Drupal::service('styling_profile.service.rule_handler_manager');
+    $stylingProfile = $styleProfileRuleHandlerManager->getStylingProfile();
+    // Add the styling profile to the cache key.
+    $cid = 'css:' . $theme_info->getName() . ':' . $stylingProfile . ':' . $language->getId() . Crypt::hashBase64(serialize($libraries_to_load)) . (int) $optimize;
+    if ($cached = $this->cache->get($cid)) {
+      return $cached->data;
+    }
+
+    $css = [];
+    $default_options = [
+      'type' => 'file',
+      'group' => CSS_AGGREGATE_DEFAULT,
+      'weight' => 0,
+      'media' => 'all',
+      'preprocess' => TRUE,
+    ];
+
+    foreach ($libraries_to_load as $key => $library) {
+      [$extension, $name] = explode('/', $library, 2);
+      $definition = $this->libraryDiscovery->getLibraryByName($extension, $name);
+      foreach ($definition['css'] as $options) {
+        $options += $default_options;
+        // Copy the asset library license information to each file.
+        $options['license'] = $definition['license'];
+
+        // Files with a query string cannot be preprocessed.
+        if ($options['type'] === 'file' && $options['preprocess'] && str_contains($options['data'], '?')) {
+          $options['preprocess'] = FALSE;
+        }
+
+        // Always add a tiny value to the weight, to conserve the insertion
+        // order.
+        $options['weight'] += count($css) / 30000;
+
+        // CSS files are being keyed by the full path.
+        $css[$options['data']] = $options;
+      }
+    }
+
+    // Allow modules and themes to alter the CSS assets.
+    $this->moduleHandler->alter('css', $css, $assets, $language);
+    $this->themeManager->alter('css', $css, $assets, $language);
+
+    if (!empty($css)) {
+      // Sort CSS items, so that they appear in the correct order.
+      uasort($css, [static::class, 'sort']);
+
+      if ($optimize) {
+        $css = \Drupal::service('asset.css.collection_optimizer')->optimize($css, array_values($libraries_to_load), $language);
+      }
+    }
+    $this->cache->set($cid, $css, CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
+
+    return $css;
+  }
+
+}

--- a/styling_profiles.services.yml
+++ b/styling_profiles.services.yml
@@ -10,3 +10,6 @@ services:
   styling_profile.service.rule_handler_manager:
     class: Drupal\styling_profiles\Service\RuleHandlerManager
     parent: default_plugin_manager
+  asset.resolver:
+    class: Drupal\styling_profiles\Asset\AssetResolver
+    arguments: ['@library.discovery', '@library.dependency_resolver', '@module_handler', '@theme.manager', '@language_manager', '@cache.data']


### PR DESCRIPTION
On some project an issue occured concerning wrong assets loaded on page.

# Original issue description
it is a cache problem with the styling profiles.

To simulate:

- Navigate to the styling profiles and check the main colors.
- Open all 4 domains in browser tabs (not logged in)
- Run a cache rebuild and compare the colors with those in the styling profile (the easiest way to recognize it is by the buttons on the start page)

What happens: The colors of the page that you call up first after the cache rebuild are also applied to all other pages.

# Root cause

The styling_profiles module rewrite css paths according to current profile through the hook_css_alter() [here](https://github.com/iqual-ch/styling_profiles/blob/7a285e186b98f72ef3ab448b46e4a13aa1237f5f/styling_profiles.module#L32).

This hook is triggered by[ \Drupal\core\Asset\AssetResolver::getCssAssets()](https://git.drupalcode.org/project/drupal/-/blob/10.3.x/core/lib/Drupal/Core/Asset/AssetResolver.php?ref_type=heads#L124)
The AssetResolver cache data for a cache id based on concatenation of the active theme, the current language and a serialization of all libraries to load.
`$cid = 'css:' . $theme_info->getName() . ':' . $language->getId() . Crypt::hashBase64(serialize($libraries_to_load)) . (int) $optimize;`

If the $cid is unchanged, then the same assets will be delivered. In our case, the active theme is always 'iq_custom', the language is the same, and the libraries to load are also exactly the sames, as the domains have very similar design.
It explains why the first generated css assets are loaded by subsequent request.

# Why problem occurs only now

The AssetLoader was updated in the drupal 10.3 version. It nows remove library without any css from the library to load, which explains why adding a dummy library to the page attachment no longer works.

As for other projects the problem is not occuring because the libraries to load vary between each domain, the domains having different component structure.

# Proposed solution

Provide our own custom Asset Loader and add the styling_profile id to the generated cache id.