### PR TITLE
DGI-4122: tmp fix broken admin styling

### DIFF
--- a/src/Asset/AssetResolver.php
+++ b/src/Asset/AssetResolver.php
@@ -77,6 +77,13 @@ class AssetResolver extends CoreAssetResolver {
    * {@inheritdoc}
    */
   public function getCssAssets(AttachedAssetsInterface $assets, $optimize, ?LanguageInterface $language = NULL) {
+    // Check if we're on an admin route and bypass custom logic
+    $route = \Drupal::routeMatch()->getRouteObject();
+    if ($route && \Drupal::service('router.admin_context')->isAdminRoute($route)) {
+        // Use parent implementation for admin routes
+        return parent::getCssAssets($assets, $optimize, $language);
+    }
+
     if (!$assets->getLibraries()) {
       return [];
     }


### PR DESCRIPTION
## The problem

Some of our admin pages had broken styling, looking like this:
<img width="1903" height="1080" alt="Bildschirmfoto 2026-01-14 um 11 26 30" src="https://github.com/user-attachments/assets/27a662d2-75bf-48ef-b946-6adf10cb45c2" />

After some debugging i found out that only routes which use a controller are affected, while _entiy_list remained fine.

Broken
```bash
ddev drush route --path=/admin/structure/block
name: block.admin_display
path: /admin/structure/block
defaults:
  _controller: '\Drupal\block\Controller\BlockListController::listing'
  _title: 'Block layout'
requirements:
  _permission: 'administer blocks'
options:
  _admin_route: true
  _access_checks:
    - access_check.permission
    - access_check.domain

```

Fine
```bash
ddev drush route --path=/admin/structure/views
name: entity.view.collection
path: /admin/structure/views
defaults:
  _entity_list: view
  _title: Views
requirements:
  _permission: 'administer views'
options:
  _admin_route: true
  _access_checks:
    - access_check.permission
    - access_check.domain
```

### The MR is a temporary fix, calling the original core function if the route is an admin page!

## Proposed solution
The styling_profiles module currently overrides Drupal's core asset.resolver service globally, but a decorator should be used instead because:
- debugging is easier
- its less likely to break with updates
- follows best practices
