### PR TITLE
DUP-291: refactor AssetResolver as decorator

### DIFF
--- a/modules/styling_profiles_domain_switch/src/Form/DomainStylingProfileSwitchConfigForm.php
+++ b/modules/styling_profiles_domain_switch/src/Form/DomainStylingProfileSwitchConfigForm.php
@@ -23,32 +23,13 @@ class DomainStylingProfileSwitchConfigForm extends ConfigFormBase {
   protected $entityTypeManager;
 
   /**
-   * Constructs a DomainStylingProfileSwitchConfigForm object.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
-    parent::__construct($config_factory);
-    $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * Create function return static domain loader configuration.
-   *
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-   *   Load the ContainerInterface.
-   *
-   * @return static
-   *   return domain loader configuration.
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-        $container->get('config.factory'),
-        $container->get('entity_type.manager')
-    );
+    $instance = parent::create($container);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+
+    return $instance;
   }
 
   /**

--- a/src/Asset/AssetResolver.php
+++ b/src/Asset/AssetResolver.php
@@ -3,23 +3,63 @@
 namespace Drupal\styling_profiles\Asset;
 
 use Drupal\Component\Utility\Crypt;
-use Drupal\Core\Asset\AssetResolver as CoreAssetResolver;
+use Drupal\Core\Asset\AssetResolverInterface;
 use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Asset\LibraryDiscoveryInterface;
-use Drupal\Core\Asset\LibraryDependencyResolverInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Asset\CssCollectionOptimizerLazy;
-use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\styling_profiles\Service\RuleHandlerManager;
 
 /**
- * Custom Asset Resolver class dependent on the styling profile.
+ * Custom Asset Resolver decorator dependent on the styling profile.
  */
-class AssetResolver extends CoreAssetResolver {
+class AssetResolver implements AssetResolverInterface {
+
+  /**
+   * The decorated asset resolver service.
+   *
+   * @var \Drupal\Core\Asset\AssetResolverInterface
+   */
+  protected $innerAssetResolver;
+
+  /**
+   * The library discovery service.
+   *
+   * @var \Drupal\Core\Asset\LibraryDiscoveryInterface
+   */
+  protected $libraryDiscovery;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The theme manager.
+   *
+   * @var \Drupal\Core\Theme\ThemeManagerInterface
+   */
+  protected $themeManager;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * The cache backend.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
 
   /**
    * The styling profile rule handler manager.
@@ -38,10 +78,10 @@ class AssetResolver extends CoreAssetResolver {
   /**
    * Constructs a new AssetResolver instance.
    *
+   * @param \Drupal\Core\Asset\AssetResolverInterface $inner_asset_resolver
+   *   The decorated asset resolver service.
    * @param \Drupal\Core\Asset\LibraryDiscoveryInterface $library_discovery
    *   The library discovery service.
-   * @param \Drupal\Core\Asset\LibraryDependencyResolverInterface $library_dependency_resolver
-   *   The library dependency resolver.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
    * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
@@ -50,27 +90,37 @@ class AssetResolver extends CoreAssetResolver {
    *   The language manager.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache backend.
-   * @param \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler
-   *   The theme handler service.
    * @param \Drupal\styling_profiles\Service\RuleHandlerManager $style_profile_rule_handler_manager
    *   The styling profile rule handler manager.
    * @param \Drupal\Core\Asset\CssCollectionOptimizerLazy $css_collection_optimizer
    *   The CSS collection optimizer.
    */
   public function __construct(
+    AssetResolverInterface $inner_asset_resolver,
     LibraryDiscoveryInterface $library_discovery,
-    LibraryDependencyResolverInterface $library_dependency_resolver,
     ModuleHandlerInterface $module_handler,
     ThemeManagerInterface $theme_manager,
     LanguageManagerInterface $language_manager,
     CacheBackendInterface $cache,
-    ThemeHandlerInterface $theme_handler,
     RuleHandlerManager $style_profile_rule_handler_manager,
     CssCollectionOptimizerLazy $css_collection_optimizer,
   ) {
-    parent::__construct($library_discovery, $library_dependency_resolver, $module_handler, $theme_manager, $language_manager, $cache, $theme_handler);
+    $this->innerAssetResolver = $inner_asset_resolver;
+    $this->libraryDiscovery = $library_discovery;
+    $this->moduleHandler = $module_handler;
+    $this->themeManager = $theme_manager;
+    $this->languageManager = $language_manager;
+    $this->cache = $cache;
     $this->styleProfileRuleHandlerManager = $style_profile_rule_handler_manager;
     $this->cssCollectionOptimizer = $css_collection_optimizer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getJsAssets(AttachedAssetsInterface $assets, $optimize, ?LanguageInterface $language = NULL): array {
+    // Delegate to the original service for JS assets.
+    return $this->innerAssetResolver->getJsAssets($assets, $optimize, $language);
   }
 
   /**
@@ -150,6 +200,14 @@ class AssetResolver extends CoreAssetResolver {
     $this->cache->set($cid, $css, CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
 
     return $css;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLibrariesToLoad(AttachedAssetsInterface $assets): array {
+    // Delegate to the original service.
+    return $this->innerAssetResolver->getLibrariesToLoad($assets);
   }
 
 }

--- a/src/Asset/AssetResolverDecorator.php
+++ b/src/Asset/AssetResolverDecorator.php
@@ -14,6 +14,8 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\AdminContext;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\styling_profiles\Service\RuleHandlerManager;
 
@@ -31,11 +33,31 @@ class AssetResolverDecorator extends AssetResolver {
    *   The styling profile rule handler manager.
    * @param \Drupal\Core\Asset\CssCollectionOptimizerLazy $cssCollectionOptimizer
    *   The CSS collection optimizer.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   *   The route match service.
+   * @param \Drupal\Core\Routing\AdminContext $adminContext
+   *   The admin context service.
+   * @param \Drupal\Core\Asset\LibraryDiscoveryInterface $library_discovery
+   *   The library discovery service.
+   * @param \Drupal\Core\Asset\LibraryDependencyResolverInterface $library_dependency_resolver
+   *   The library dependency resolver service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
+   *   The theme manager.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The cache backend.
+   * @param \Drupal\Core\Extension\ThemeHandlerInterface|null $theme_handler
+   *   The theme handler.
    */
   public function __construct(
     protected AssetResolverInterface $innerAssetResolver,
     protected RuleHandlerManager $styleProfileRuleHandlerManager,
     protected CssCollectionOptimizerLazy $cssCollectionOptimizer,
+    protected RouteMatchInterface $routeMatch,
+    protected AdminContext $adminContext,
     LibraryDiscoveryInterface $library_discovery,
     LibraryDependencyResolverInterface $library_dependency_resolver,
     ModuleHandlerInterface $module_handler,
@@ -59,6 +81,13 @@ class AssetResolverDecorator extends AssetResolver {
    * {@inheritdoc}
    */
   public function getCssAssets(AttachedAssetsInterface $assets, $optimize, ?LanguageInterface $language = NULL) {
+    // Check if we're on an admin route and bypass custom logic.
+    $route = $this->routeMatch->getRouteObject();
+    if ($route && $this->adminContext->isAdminRoute($route)) {
+      // Use parent implementation for admin routes.
+      return parent::getCssAssets($assets, $optimize, $language);
+    }
+
     if (!$assets->getLibraries()) {
       return [];
     }

--- a/src/Asset/AssetResolverDecorator.php
+++ b/src/Asset/AssetResolverDecorator.php
@@ -3,124 +3,56 @@
 namespace Drupal\styling_profiles\Asset;
 
 use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Asset\AssetResolver;
 use Drupal\Core\Asset\AssetResolverInterface;
 use Drupal\Core\Asset\AttachedAssetsInterface;
-use Drupal\Core\Cache\CacheBackendInterface;
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Asset\LibraryDiscoveryInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Theme\ThemeManagerInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Asset\CssCollectionOptimizerLazy;
+use Drupal\Core\Asset\LibraryDependencyResolverInterface;
+use Drupal\Core\Asset\LibraryDiscoveryInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ThemeHandlerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\styling_profiles\Service\RuleHandlerManager;
 
 /**
  * Custom Asset Resolver decorator dependent on the styling profile.
  */
-class AssetResolver implements AssetResolverInterface {
+class AssetResolverDecorator extends AssetResolver {
 
   /**
-   * The decorated asset resolver service.
+   * Constructs a new AssetResolverDecorator instance.
    *
-   * @var \Drupal\Core\Asset\AssetResolverInterface
-   */
-  protected $innerAssetResolver;
-
-  /**
-   * The library discovery service.
-   *
-   * @var \Drupal\Core\Asset\LibraryDiscoveryInterface
-   */
-  protected $libraryDiscovery;
-
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * The theme manager.
-   *
-   * @var \Drupal\Core\Theme\ThemeManagerInterface
-   */
-  protected $themeManager;
-
-  /**
-   * The language manager.
-   *
-   * @var \Drupal\Core\Language\LanguageManagerInterface
-   */
-  protected $languageManager;
-
-  /**
-   * The cache backend.
-   *
-   * @var \Drupal\Core\Cache\CacheBackendInterface
-   */
-  protected $cache;
-
-  /**
-   * The styling profile rule handler manager.
-   *
-   * @var \Drupal\styling_profiles\Service\RuleHandlerManagerInterface
-   */
-  protected $styleProfileRuleHandlerManager;
-
-  /**
-   * The CSS collection optimizer.
-   *
-   * @var \Drupal\Core\Asset\CssCollectionOptimizerInterface
-   */
-  protected $cssCollectionOptimizer;
-
-  /**
-   * Constructs a new AssetResolver instance.
-   *
-   * @param \Drupal\Core\Asset\AssetResolverInterface $inner_asset_resolver
+   * @param \Drupal\Core\Asset\AssetResolverInterface $innerAssetResolver
    *   The decorated asset resolver service.
-   * @param \Drupal\Core\Asset\LibraryDiscoveryInterface $library_discovery
-   *   The library discovery service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
-   *   The theme manager.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The language manager.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
-   *   The cache backend.
-   * @param \Drupal\styling_profiles\Service\RuleHandlerManager $style_profile_rule_handler_manager
+   * @param \Drupal\styling_profiles\Service\RuleHandlerManager $styleProfileRuleHandlerManager
    *   The styling profile rule handler manager.
-   * @param \Drupal\Core\Asset\CssCollectionOptimizerLazy $css_collection_optimizer
+   * @param \Drupal\Core\Asset\CssCollectionOptimizerLazy $cssCollectionOptimizer
    *   The CSS collection optimizer.
    */
   public function __construct(
-    AssetResolverInterface $inner_asset_resolver,
+    protected AssetResolverInterface $innerAssetResolver,
+    protected RuleHandlerManager $styleProfileRuleHandlerManager,
+    protected CssCollectionOptimizerLazy $cssCollectionOptimizer,
     LibraryDiscoveryInterface $library_discovery,
+    LibraryDependencyResolverInterface $library_dependency_resolver,
     ModuleHandlerInterface $module_handler,
     ThemeManagerInterface $theme_manager,
     LanguageManagerInterface $language_manager,
     CacheBackendInterface $cache,
-    RuleHandlerManager $style_profile_rule_handler_manager,
-    CssCollectionOptimizerLazy $css_collection_optimizer,
+    ?ThemeHandlerInterface $theme_handler = NULL,
   ) {
-    $this->innerAssetResolver = $inner_asset_resolver;
-    $this->libraryDiscovery = $library_discovery;
-    $this->moduleHandler = $module_handler;
-    $this->themeManager = $theme_manager;
-    $this->languageManager = $language_manager;
-    $this->cache = $cache;
-    $this->styleProfileRuleHandlerManager = $style_profile_rule_handler_manager;
-    $this->cssCollectionOptimizer = $css_collection_optimizer;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getJsAssets(AttachedAssetsInterface $assets, $optimize, ?LanguageInterface $language = NULL): array {
-    // Delegate to the original service for JS assets.
-    return $this->innerAssetResolver->getJsAssets($assets, $optimize, $language);
+    parent::__construct(
+      $library_discovery,
+      $library_dependency_resolver,
+      $module_handler,
+      $theme_manager,
+      $language_manager,
+      $cache,
+      $theme_handler
+    );
   }
 
   /**
@@ -200,14 +132,6 @@ class AssetResolver implements AssetResolverInterface {
     $this->cache->set($cid, $css, CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
 
     return $css;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getLibrariesToLoad(AttachedAssetsInterface $assets): array {
-    // Delegate to the original service.
-    return $this->innerAssetResolver->getLibrariesToLoad($assets);
   }
 
 }

--- a/styling_profiles.services.yml
+++ b/styling_profiles.services.yml
@@ -20,6 +20,8 @@ services:
       - '@original_asset_resolver'
       - '@styling_profile.service.rule_handler_manager'
       - '@asset.css.collection_optimizer'
+      - '@current_route_match'
+      - '@router.admin_context'
       - '@library.discovery'
       - '@library.dependency_resolver'
       - '@module_handler'

--- a/styling_profiles.services.yml
+++ b/styling_profiles.services.yml
@@ -10,15 +10,16 @@ services:
   styling_profile.service.rule_handler_manager:
     class: Drupal\styling_profiles\Service\RuleHandlerManager
     parent: default_plugin_manager
-  asset.resolver:
+  styling_profiles.asset.resolver:
     class: Drupal\styling_profiles\Asset\AssetResolver
+    decorates: asset.resolver
+    decoration_priority: -10
     arguments:
+      - '@styling_profiles.asset.resolver.inner'
       - '@library.discovery'
-      - '@library.dependency_resolver'
       - '@module_handler'
       - '@theme.manager'
       - '@language_manager'
       - '@cache.asset_chain'
-      - '@theme_handler'
       - '@styling_profile.service.rule_handler_manager'
       - '@asset.css.collection_optimizer'

--- a/styling_profiles.services.yml
+++ b/styling_profiles.services.yml
@@ -10,16 +10,20 @@ services:
   styling_profile.service.rule_handler_manager:
     class: Drupal\styling_profiles\Service\RuleHandlerManager
     parent: default_plugin_manager
-  styling_profiles.asset.resolver:
-    class: Drupal\styling_profiles\Asset\AssetResolver
+  styling_profiles.asset.resolver.decorator:
+    public: false
+    class: Drupal\styling_profiles\Asset\AssetResolverDecorator
     decorates: asset.resolver
-    decoration_priority: -10
+    decoration_inner_name: 'original_asset_resolver'
+    decoration_priority: 5
     arguments:
-      - '@styling_profiles.asset.resolver.inner'
+      - '@original_asset_resolver'
+      - '@styling_profile.service.rule_handler_manager'
+      - '@asset.css.collection_optimizer'
       - '@library.discovery'
+      - '@library.dependency_resolver'
       - '@module_handler'
       - '@theme.manager'
       - '@language_manager'
       - '@cache.asset_chain'
-      - '@styling_profile.service.rule_handler_manager'
-      - '@asset.css.collection_optimizer'
+      - '@theme_handler'


### PR DESCRIPTION
# Issue
Some of the admin/backend pages' styling is broken. 


The styling_profiles module overwrites the Drupal core’s asset resolver service. Which apparently breaks some of these admin pages.

# Fix
This PR refactor the AssetsResolver as a decorator of the Core AssetResolver and add proper handling of admin route

